### PR TITLE
update development/statfullset from apps/v1beta2 to apps/v1

### DIFF
--- a/k8s/build.yml
+++ b/k8s/build.yml
@@ -55,7 +55,7 @@ subjects:
 
 ---
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: db
@@ -129,7 +129,7 @@ spec:
 
 ---
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api

--- a/k8s/prod.yml
+++ b/k8s/prod.yml
@@ -53,7 +53,7 @@ subjects:
 
 ---
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: db
@@ -127,7 +127,7 @@ spec:
 
 ---
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api


### PR DESCRIPTION
$ kk apply -f k8s/buid.yml --record
unable to recognize "k8s/build.yml": no matches for kind "StatefulSet" in version "apps/v1beta2"
unable to recognize "k8s/build.yml": no matches for kind "Deployment" in version "apps/v1beta2"

StatefulSet and Deployment is not in apps/v1beta2 anymore